### PR TITLE
Fixing some issues with AutoComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [CHANGELOG.md](https://github.com/mbrookes/formsy-material-ui/blob/master/CH
 
 ## Acknowledgements
 
-Originally based on an example by [Ryan Blakeley](https://github.com/rojobuffalo).
+Originally started by [Matt Brookes](https://github.com/mbrookes) and later transfered.
 
 Thanks to our [contributors](https://github.com/mbrookes/formsy-material-ui/graphs/contributors).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsy-material-ui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/FormsyAutoComplete.jsx
+++ b/src/FormsyAutoComplete.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import keycode from 'keycode';
 import Formsy from 'formsy-react';
 import AutoComplete from 'material-ui/AutoComplete';
-import { setMuiComponentAndMaybeFocus } from 'formsy-react/src/utils';
+import { setMuiComponentAndMaybeFocus } from './utils';
 
 const FormsyAutoComplete = createClass({
 
@@ -39,16 +39,12 @@ const FormsyAutoComplete = createClass({
   },
 
   handleChange: function handleChange(event) {
-    this.setState({
-      value: event.currentTarget.value,
-    });
+    this.setState({ value: event.currentTarget.value }, () => this.setValue(event.currentTarget.value));
     if (this.props.onChange) this.props.onChange(event);
   },
 
   handleUpdateInput: function handleUpdateInput(value) {
-    this.setState({
-      value,
-    });
+    this.setState({ value }, () => this.setValue(value));
     if (this.props.onChange) this.props.onChange(null, value);
   },
 

--- a/src/FormsySelect.jsx
+++ b/src/FormsySelect.jsx
@@ -45,6 +45,7 @@ const FormsySelect = createClass({
       validationError, // eslint-disable-line no-unused-vars
       validationErrors, // eslint-disable-line no-unused-vars
       value: valueProp,
+      onChange,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
Background issues:

1. If using FormsyAutoComplete a user begins to type and uses the keyboard to select the first option in the AutoComplete menus (Keyboard, not mouse click) handleBlur will set _value before the selected autocomplete item text is set in the input.

2. If, for some reason, blur is not triggered on the AutoComplete element, an incorrect value can be set for the formsy element/model.

3. Could not reset MUI AutoComplete component using `[AutoCompleteComponent].setState({ searchText: '' })` because FormsyAutoComplete did not provide access to component.

This PR: 
- Gives access to muiComponent
- Uses `setValue` instead of `setState`